### PR TITLE
[OWL-370] Remove the `git clean` commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+*.log*
+/logs
+/bin
+/config
+open-falcon

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOTOOLS = github.com/mitchellh/gox golang.org/x/tools/cmd/stringer \
 PACKAGES=$(shell go list ./... | grep -v '^github.com/Cepave/open-falcon/')
 VERSION?=$(shell awk -F\" '/^const Version/ { print $$2; exit }' ./g/version.go)
 
-all: $(BIN) $(TARGET)
+all: $(BIN) $(TARGET) bin/falcon-fe
 
 $(CMD):
 	make bin/falcon-$@
@@ -40,8 +40,6 @@ pack: checkbin
 	tar -zcvf open-falcon-v$(VERSION).tar.gz ./bin ./config ./open-falcon ./cfg.json
 
 clean:
-	git clean -f -d ./bin
-	git clean -f -d ./config
 	rm -rf ./bin
 	rm -rf ./$(TARGET)
 	rm -rf open-falcon-v$(VERSION).tar.gz


### PR DESCRIPTION
These commands are not needed after creating the `.gitignore` file. Also, I fixed the bug that `make all` won't make the `fe`
