### PR TITLE
[OWL-370] Fix a bug in packed directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ format:
 tools:
 	go get -u -v $(GOTOOLS)
 
-checkbin:
+checkbin: bin/ config/ open-falcon cfg.json
 pack: checkbin
 	rm -rf open-falcon-v$(VERSION).tar.gz
 	tar -zcvf open-falcon-v$(VERSION).tar.gz ./bin ./config ./open-falcon ./cfg.json

--- a/Makefile
+++ b/Makefile
@@ -58,5 +58,6 @@ bin/falcon-task : $(shell find modules/task/ -name '*.go')
 bin/falcon-transfer : $(shell find modules/transfer/ -name '*.go')
 bin/falcon-fe: $(shell find modules/fe/ -name '*.go')
 	go build -o $@ github.com/Cepave/open-falcon/modules/$(@:bin/falcon-%=%)
-	cd bin; ln -s ../modules/fe fe
+	mkdir -p bin/fe
+	cp -r modules/fe/{control,cfg.example.json,conf,static,views,scripts} bin/fe/
 	cp bin/falcon-fe bin/fe/falcon-fe


### PR DESCRIPTION
In the packed directory, the symbolic link of `fe` is not able to find the directory `modules/fe` because we don't pack the source code directories. Now we copy a working directory instead. I also added the prerequisites for `checkbin` so it checks if the files and the directories exist before the `make pack` command.
