### PR TITLE
[OWL-370] Specify the `SHELL` variable as BASH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 TARGET_SOURCE = $(shell find main.go g commands -name '*.go')
 CMD = agent aggregator graph hbs judge nodata query sender task transfer fe
 BIN = bin/falcon-agent bin/falcon-aggregator bin/falcon-graph bin/falcon-hbs bin/falcon-judge bin/falcon-nodata bin/falcon-query bin/falcon-sender bin/falcon-task bin/falcon-transfer


### PR DESCRIPTION
The default shell in Makefile is `/bin/sh` which doesn't support commands in this form: `cp {src1,src2} target/`. I Specified the default shell as `/bin/bash`.
